### PR TITLE
cd to $HOME if no arguments are passed to 'cd'

### DIFF
--- a/alwaysontop.sh
+++ b/alwaysontop.sh
@@ -176,7 +176,11 @@ function cdls {
     DISPLAY_LINES=20
     LSCMD="CLICOLOR_FORCE=1 COLUMNS=$(tput cols) ls -Gp -x "
     DIR="$@"  
-    
+   
+    if [[ "$@" == "" ]]
+    then
+      DIR="$HOME"
+    fi
 
     GIT_CMD="git -c color.status=always status -bs 2>/dev/null"
     SVN_CMD='[[ -d .svn ]] && (


### PR DESCRIPTION
I use 'cd' to jump to home directory a lot.  This does just that.
